### PR TITLE
Subaddress unit tests

### DIFF
--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -54,6 +54,7 @@ set(unit_tests_sources
   parse_amount.cpp
   serialization.cpp
   slow_memmem.cpp
+  subaddress.cpp
   test_tx_utils.cpp
   test_peerlist.cpp
   test_protocol_pack.cpp

--- a/tests/unit_tests/subaddress.cpp
+++ b/tests/unit_tests/subaddress.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2014-2017, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+#include <boost/filesystem.hpp>
+#include "gtest/gtest.h"
+
+#include "include_base_utils.h"
+#include "wallet/wallet2.h"
+#include "crypto/crypto.h"
+#include "cryptonote_basic/account.h"
+#include "cryptonote_basic/cryptonote_basic_impl.h"
+#include "wallet/api/subaddress.h"
+
+class WalletSubaddress : public ::testing::Test 
+{
+  protected:
+    virtual void SetUp() 
+    {
+      try
+      {
+          w1.generate(wallet_name, password, recovery_key, true, false);
+      }
+      catch (const std::exception& e)
+      {
+          LOG_ERROR("failed to generate wallet: " << e.what());
+      }
+
+      w1.add_subaddress_account(test_label);
+      w1.set_subaddress_label(subaddress_index, test_label);
+    }
+
+    virtual void TearDown() 
+    {
+        boost::filesystem::wpath wallet_file(wallet_name);
+        boost::filesystem::wpath wallet_address_file(wallet_name + ".address.txt");
+        boost::filesystem::wpath wallet_keys_file(wallet_name + ".keys");
+
+        if ( boost::filesystem::exists(wallet_file) )
+            boost::filesystem::remove(wallet_file);
+        
+        if ( boost::filesystem::exists(wallet_address_file) )
+            boost::filesystem::remove(wallet_address_file);
+
+        if ( boost::filesystem::exists(wallet_keys_file) )
+            boost::filesystem::remove(wallet_keys_file);
+    }
+
+
+    tools::wallet2 w1;
+    std::string path_working_dir = ".";
+    std::string path_test_wallet = "test_wallet";
+    const std::string wallet_name = path_working_dir + "/" + path_test_wallet;
+    const std::string password = "testpass";
+    crypto::secret_key recovery_key = crypto::secret_key();
+    const std::string test_label = "subaddress test label";
+
+    uint32_t major_index = 0;
+    uint32_t minor_index = 0;
+    const cryptonote::subaddress_index subaddress_index = {major_index, minor_index};
+};
+
+TEST_F(WalletSubaddress, AddRow)
+{
+    EXPECT_EQ(test_label, w1.get_subaddress_label(subaddress_index));
+}

--- a/tests/unit_tests/subaddress.cpp
+++ b/tests/unit_tests/subaddress.cpp
@@ -55,7 +55,7 @@ class WalletSubaddress : public ::testing::Test
       w1.set_subaddress_label(subaddress_index, test_label);
     }
 
-    virtual void TearDown() 
+    virtual void TearDown()
     {
         boost::filesystem::wpath wallet_file(wallet_name);
         boost::filesystem::wpath wallet_address_file(wallet_name + ".address.txt");
@@ -63,7 +63,7 @@ class WalletSubaddress : public ::testing::Test
 
         if ( boost::filesystem::exists(wallet_file) )
             boost::filesystem::remove(wallet_file);
-        
+
         if ( boost::filesystem::exists(wallet_address_file) )
             boost::filesystem::remove(wallet_address_file);
 


### PR DESCRIPTION
Created unit test for the new subaddress feature, testing the creation and relabeling of a subaddress account. Using this test fixture `w1` starts as wallet with one primary subaddress account. From here it should be fairly easy to test the rest of the subaddress functionality the wallet provides. 

`TearDown()` deletes test wallet files after the final (only) unit test using the `WalletSubaddress` class finishes, and the class's destructor is called. If you wish to preserve these test files, remove the lines in `TearDown()`, and generate the wallet from the file instead.